### PR TITLE
Use `Symbol.for` to create `Symbol.observable` if it does not exist.

### DIFF
--- a/src/Observable.js
+++ b/src/Observable.js
@@ -28,7 +28,15 @@ function hasSymbol(name) {
 
 function getSymbol(name) {
 
-    return hasSymbol(name) ? Symbol[name] : "@@" + name;
+    if (hasSymbol(name)) {
+        return Symbol[name]
+    }
+
+    if (typeof Symbol === "function" && typeof Symbol["for"] === "function") {
+        return Symbol[name] = Symbol["for"](name);
+    }
+
+    return "@@" + name;
 }
 
 // === Abstract Operations ===


### PR DESCRIPTION
This is the method used by `symbol-observable` and other packages (including RxJs/Observables).

The current usage is causing false negatives from the `is-observable` package in latest Node.