### PR TITLE
Fix crash on `ctor[Symbol.species]` not set

### DIFF
--- a/src/Observable.js
+++ b/src/Observable.js
@@ -28,7 +28,7 @@ function getMethod(obj, key) {
 function getSpecies(ctor) {
 
     let symbol = getSymbol("species");
-    return symbol ? ctor[symbol] : ctor;
+    return symbol && ctor[symbol] ? ctor[symbol] : ctor;
 }
 
 function addMethods(target, methods) {


### PR DESCRIPTION
Hey there!

I just encountered a problem. `ctor[Symbol.species]` seems to be `undefined` in one of my use cases and I really can't tell why. Everything else seems to be alright, though.

So if it's possible that there is no `Symbol.species` set I propose a fallback for that case.

Objections?

Thx in advance!