### PR TITLE
Immediately throw if forEach not passed a function

### DIFF
--- a/src/Observable.js
+++ b/src/Observable.js
@@ -256,10 +256,10 @@ addMethods(Observable.prototype, {
 
     forEach(fn) {
 
-        return new Promise((resolve, reject) => {
+        if (typeof fn !== "function")
+               throw new TypeError(fn + " is not a function"));
 
-            if (typeof fn !== "function")
-                return Promise.reject(new TypeError(fn + " is not a function"));
+        return new Promise((resolve, reject) => {
 
             this.subscribe({
 


### PR DESCRIPTION
Don't make this catchable in a promise.