### PR TITLE
Adjusts default.js to be in line with docs, and adds package fields.

### DIFF
--- a/default.js
+++ b/default.js
@@ -1,1 +1,3 @@
-export * from "./src/Observable.js";
+import { Observable } from "./src/Observable.js";
+
+export default Observable;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "An Implementation of ES Observables",
   "homepage": "https://github.com/zenparsing/zen-observable",
   "license": "MIT",
+  "main": "index.js",
+  "module": "default.js",
   "devDependencies": {
     "es-observable-tests": "^0.2.8",
     "moon-unit": "^0.2.1",


### PR DESCRIPTION
I'm using ES2015 modules (particularly with rollup) a lot for my personal projects these days. zen-observable almost works, but there were a couple of snags which this PR addresses. The docs suggest what this module can be required in using:

```javascript
import Observable from "zen-observable";
```

but with default.js and the package file as they are in master this line needs to be:

```javascript
import { Observable } from "zen-observable/default.js";
```

This PR adjusts default.js and adds a `module` field to the package file for rollup to pick up (and I'm told webpack too). [This field is to ES2015 modules as the `main` field is to Node style CommonJS modules](https://github.com/rollup/rollup/wiki/pkg.module). These changes bring the behaviour of this module into line with the docs without affecting internal modules.