### PR TITLE
Export default from index for CommonJS style

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,3 @@
 module.exports = require("./zen-observable.js").Observable;
+module.exports.default = require("./zen-observable.js").Observable;
+


### PR DESCRIPTION
The issue is that the CommonJs form does not export a `default` property, so we need it in order to be compatible with the ES6 model of exporting. Please see this [Stack Overflow question](https://stackoverflow.com/questions/40294870/module-exports-vs-export-default-in-node-js-and-es6) for more background.

This is an incredible library and we would like to continue using it, so if you want to go in another direction, please let me know how I can help you with that.

Fixes #31 

Will also need to `export default Observable` in the [typings](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/zen-observable/index.d.ts).