### PR TITLE
error should not return values

### DIFF
--- a/src/Observable.js
+++ b/src/Observable.js
@@ -171,14 +171,13 @@ addMethods(SubscriptionObserver.prototype = {}, {
       if (!m)
         throw value;
 
-      value = m.call(observer, value);
+      m.call(observer, value);
     } catch (e) {
       try { cleanupSubscription(subscription) }
       finally { throw e }
     }
 
     cleanupSubscription(subscription);
-    return value;
   },
 
   complete(value) {

--- a/zen-observable.js
+++ b/zen-observable.js
@@ -171,14 +171,13 @@ addMethods(SubscriptionObserver.prototype = {}, {
       if (!m$0)
         throw value;
 
-      value = m$0.call(observer, value);
+      m$0.call(observer, value);
     } catch (e) {
       try { cleanupSubscription(subscription) }
       finally { throw e }
     }
 
     cleanupSubscription(subscription);
-    return value;
   },
 
   complete: function(value) {
@@ -217,7 +216,7 @@ function Observable(subscriber) {
 
 addMethods(Observable.prototype, {
 
-  subscribe: function(observer) { for (var args = [], __$0 = 1; __$0 < arguments.length; ++__$0) args.push(arguments[__$0]); 
+  subscribe: function(observer) { for (var args = [], __$0 = 1; __$0 < arguments.length; ++__$0) args.push(arguments[__$0]);
     if (typeof observer === 'function') {
       observer = {
         next: observer,
@@ -229,7 +228,7 @@ addMethods(Observable.prototype, {
     return new Subscription(observer, this._subscriber);
   },
 
-  forEach: function(fn) { var __this = this; 
+  forEach: function(fn) { var __this = this;
     return new Promise(function(resolve, reject) {
       if (typeof fn !== "function")
         return Promise.reject(new TypeError(fn + " is not a function"));
@@ -264,7 +263,7 @@ addMethods(Observable.prototype, {
     });
   },
 
-  map: function(fn) { var __this = this; 
+  map: function(fn) { var __this = this;
     if (typeof fn !== "function")
       throw new TypeError(fn + " is not a function");
 
@@ -286,7 +285,7 @@ addMethods(Observable.prototype, {
     }); });
   },
 
-  filter: function(fn) { var __this = this; 
+  filter: function(fn) { var __this = this;
     if (typeof fn !== "function")
       throw new TypeError(fn + " is not a function");
 
@@ -308,7 +307,7 @@ addMethods(Observable.prototype, {
     }); });
   },
 
-  reduce: function(fn) { var __this = this; 
+  reduce: function(fn) { var __this = this;
     if (typeof fn !== "function")
       throw new TypeError(fn + " is not a function");
 
@@ -350,7 +349,7 @@ addMethods(Observable.prototype, {
     }); });
   },
 
-  flatMap: function(fn) { var __this = this; 
+  flatMap: function(fn) { var __this = this;
     if (typeof fn !== "function")
       throw new TypeError(fn + " is not a function");
 
@@ -446,7 +445,7 @@ addMethods(Observable, {
 
     if (hasSymbol("iterator") && (method = getMethod(x, getSymbol("iterator")))) {
       return new C(function(observer) {
-        for (var __$0 = (method.call(x))[Symbol.iterator](), __$1; __$1 = __$0.next(), !__$1.done;) { var item$0 = __$1.value; 
+        for (var __$0 = (method.call(x))[Symbol.iterator](), __$1; __$1 = __$0.next(), !__$1.done;) { var item$0 = __$1.value;
           observer.next(item$0);
           if (observer.closed)
             return;
@@ -471,7 +470,7 @@ addMethods(Observable, {
     throw new TypeError(x + " is not observable");
   },
 
-  of: function() { for (var items = [], __$0 = 0; __$0 < arguments.length; ++__$0) items.push(arguments[__$0]); 
+  of: function() { for (var items = [], __$0 = 0; __$0 < arguments.length; ++__$0) items.push(arguments[__$0]);
     var C = typeof this === "function" ? this : Observable;
 
     return new C(function(observer) {


### PR DESCRIPTION
While I was making a typescript version, SubscriptionObserver returning a value caused an error in my tests. Was due to an `error` function that returned something nonvoid, so arguably the failure was totally reasonable. Up to you what is best