### PR TITLE
Bind observer functions to 'this'

### DIFF
--- a/src/Observable.js
+++ b/src/Observable.js
@@ -184,7 +184,12 @@ class Subscription {
 }
 
 class SubscriptionObserver {
-  constructor(subscription) { this._subscription = subscription }
+  constructor(subscription) {
+    this._subscription = subscription;
+    this.next = this.next.bind(this);
+    this.error = this.error.bind(this);
+    this.complete = this.complete.bind(this);
+  }
   get closed() { return this._subscription._state === 'closed' }
   next(value) { onNotify(this._subscription, 'next', value) }
   error(value) { onNotify(this._subscription, 'error', value) }


### PR DESCRIPTION
bind observer functions to 'this' to avoid undefined this._subscription errors like this:
```
Uncaught TypeError: Cannot read property '_state' of undefined
      at onNotify (node_modules/zen-observable/lib/Observable.js:145:20)
      at Object.error [as onAbort] (node_modules/zen-observable/lib/Observable.js:220:7)
      at node_modules/@absinthe/socket/src/notifier/notify.js:6:37
```