### PR TITLE
Propagate unsubscribe to subscription and *then* clear it

### DIFF
--- a/src/Observable.js
+++ b/src/Observable.js
@@ -337,8 +337,8 @@ export class Observable {
 
       return () => {
         if (subscription) {
-          subscription = undefined;
           subscription.unsubscribe();
+          subscription = undefined;
         }
       };
     });


### PR DESCRIPTION
Getting some "Cannot read property 'unsubscribe' of undefined" errors which appear to occur when unsubscribing from the result of "concat()"
