### PR TITLE
Avoid mutating varargs array of Observable.concat

### DIFF
--- a/src/Observable.js
+++ b/src/Observable.js
@@ -321,17 +321,18 @@ export class Observable {
 
     return new C(observer => {
       let subscription;
+      let index = 0;
 
       function startNext(next) {
         subscription = next.subscribe({
           next(v) { observer.next(v) },
           error(e) { observer.error(e) },
           complete() {
-            if (sources.length === 0) {
+            if (index === sources.length) {
               subscription = undefined;
               observer.complete();
             } else {
-              startNext(C.from(sources.shift()));
+              startNext(C.from(sources[index++]));
             }
           },
         });

--- a/test/concat.js
+++ b/test/concat.js
@@ -11,4 +11,20 @@ describe('concat', () => {
 
     assert.deepEqual(list, [1, 2, 3, 4, 5, 6, 7]);
   });
+
+  it('can be used multiple times to produce the same results', async () => {
+    const list1 = [];
+    const list2 = [];
+
+    const concatenated = Observable.from([1, 2, 3, 4])
+      .concat(Observable.of(5, 6, 7));
+
+    await concatenated
+      .forEach(x => list1.push(x));
+    await concatenated
+      .forEach(x => list2.push(x));
+
+    assert.deepEqual(list1, [1, 2, 3, 4, 5, 6, 7]);
+    assert.deepEqual(list2, [1, 2, 3, 4, 5, 6, 7]);
+  });
 });


### PR DESCRIPTION
This means the result of concat can be observed multiple times and
return the same result, as opposed to only passing on to the additional
sources the first time.