### PR TITLE
Create .mjs entry points for module bundlers supporting ESM.

### DIFF
--- a/extras.mjs
+++ b/extras.mjs
@@ -1,0 +1,1 @@
+export * from './src/extras.js';

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,1 @@
+export { Observable as default } from './src/Observable.js';


### PR DESCRIPTION
In modern bundlers (ex: [Webpack][1] and [Rollup][2]), .mjs have a higher priority than .js.  This change will make those load ES modules instead of the commonjs versions, so the code can be [treeshaked][3] and [hoisted][4].

This will bypass the Babel build, but in general bundlers will use a compiler to support the ES* features needed.

[1]: https://webpack.js.org/configuration/resolve/#resolve-extensions
[2]: https://github.com/rollup/rollup-plugin-node-resolve#usage
[3]: https://webpack.js.org/guides/tree-shaking/
[4]: https://webpack.js.org/plugins/module-concatenation-plugin/