### PR TITLE
Support usage from immutable realms

### DIFF
--- a/src/Observable.js
+++ b/src/Observable.js
@@ -4,8 +4,14 @@ const hasSymbols = () => typeof Symbol === 'function';
 const hasSymbol = name => hasSymbols() && Boolean(Symbol[name]);
 const getSymbol = name => hasSymbol(name) ? Symbol[name] : '@@' + name;
 
-if (hasSymbols() && !hasSymbol('observable') && Object.isExtensible(Symbol)) {
-  Symbol.observable = Symbol('observable');
+export const polyfillSymbol = (symbolConstructor) => {
+  if (Object.isExtensible(symbolConstructor)) {
+    symbolConstructor.observable = symbolConstructor('observable');
+  }
+};
+
+if (hasSymbols() && !hasSymbol('observable')) {
+  polyfillSymbol(Symbol);
 }
 
 const SymbolIterator = getSymbol('iterator');

--- a/src/Observable.js
+++ b/src/Observable.js
@@ -4,7 +4,7 @@ const hasSymbols = () => typeof Symbol === 'function';
 const hasSymbol = name => hasSymbols() && Boolean(Symbol[name]);
 const getSymbol = name => hasSymbol(name) ? Symbol[name] : '@@' + name;
 
-if (hasSymbols() && !hasSymbol('observable')) {
+if (hasSymbols() && !hasSymbol('observable') && Object.isExtensible(Symbol)) {
   Symbol.observable = Symbol('observable');
 }
 

--- a/test/polyfill-symbol.js
+++ b/test/polyfill-symbol.js
@@ -1,0 +1,44 @@
+import assert from 'assert';
+import { polyfillSymbol } from '../src/Observable.js';
+
+describe('symbol polyfilling', () => {
+  it('extends the provided object', () => {
+    const returnValue = {};
+    const fakeSymbol = () => returnValue;
+
+    polyfillSymbol(fakeSymbol);
+
+    const desc = Object.getOwnPropertyDescriptor(fakeSymbol, 'observable');
+    assert(!!desc, 'property descriptor present');
+    assert.equal(desc.writable, true, 'writable');
+    assert.equal(desc.enumerable, true, 'enumerable');
+    assert.equal(desc.configurable, true, 'configurable');
+    assert.equal(desc.value, returnValue);
+  });
+
+  it('constructs the expected value', () => {
+    const observed = {
+      callCount: 0
+    };
+    const fakeSymbol = function(...args) {
+      observed.callCount += 1;
+      observed.newTarget = new.target;
+      observed.thisValue = this;
+      observed.args = args;
+    };
+
+    polyfillSymbol(fakeSymbol);
+
+    assert.equal(observed.callCount, 1, 'call count');
+    assert.equal(observed.newTarget, undefined, 'new.target');
+    assert.equal(observed.thisValue, undefined, '"this" value');
+    assert.deepEqual(observed.args, ['observable'], 'arguments');
+  });
+
+  it('tolerates non-extensible objects (in support of immutable realms)', () => {
+    const fakeSymbol = () => {};
+    Object.freeze(fakeSymbol);
+
+    polyfillSymbol(fakeSymbol);
+  });
+});


### PR DESCRIPTION
Thanks for the library, @zenparsing! I'm working in an environment that implements an "immutable realm" as described by [the SES proposal](https://github.com/tc39/proposal-ses). That means the `Symbol` constructor is not extensible, so the property definition fails.

Would you be open to supporting that use case? If so, I can extend this patch with a test. Here are a couple ideas along those lines:

- create a temporary copy of the source file with `Object.freeze(Symbol);` injected as the first statement. Use `child_process.fork` and verify that the child exits gracefully
- Use [the unstable `vm.Module` API](https://nodejs.org/api/vm.html#vm_class_vm_module) to prepare an environment from which the source module can be imported (I'm not sure this is actually possible)

...though I'm all ears if you have other ideas