### PR TITLE
Add module field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "An Implementation of ES Observables",
   "homepage": "https://github.com/zenparsing/zen-observable",
   "license": "MIT",
+  "main": "index.js",
+  "module": "esm.js",
   "devDependencies": {
     "@babel/cli": "^7.6.0",
     "@babel/core": "^7.6.0",


### PR DESCRIPTION
Meanwhile we wait for something like #64 (#62), we can add the `module` field to `package.json`.

With this, we can fix issues like: https://github.com/apollographql/apollo-client/issues/5961

Reference: https://github.com/apollographql/apollo-client/issues/5961#issuecomment-588245785