### PR TITLE
Avoid publishing unwanted files in the npm tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-.DS_Store
-node_modules

--- a/package.json
+++ b/package.json
@@ -13,6 +13,12 @@
     "eslint": "^6.5.0",
     "mocha": "^6.2.0"
   },
+  "files": [
+    "index.js",
+    "esm.js",
+    "extras.js",
+    "lib"
+  ],
   "dependencies": {},
   "scripts": {
     "test": "mocha --recursive --require ./scripts/mocha-require",


### PR DESCRIPTION
Hi,

This pull-request add a "files" field in the package.json to avoid publishing unwanted files in the npm tarball. The files field is a whitelist, more info here: https://docs.npmjs.com/files/package.json#files

The PR remove the .npmignore file (useless now).

List of files that are not published anymore with this PR
- .editorconfig
- .eslintrc.js
- .gitignore
- everything in scripts/
- everything in test/
- everything in src/

Hope i have not missed something

> Note: I know that sometimes some authors like to keep the tests in tarball.. but because i was not sure i'v not included the test directory.

Best Regards,
Thomas