### PR TITLE
Add node@14 ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "description": "An Implementation of ES Observables",
   "homepage": "https://github.com/zenparsing/zen-observable",
   "license": "MIT",
+  "type": "module",
+  "exports": {
+    "import": "./esm.js",
+    "require": "./index.js"
+  },
   "devDependencies": {
     "@babel/cli": "^7.6.0",
     "@babel/core": "^7.6.0",


### PR DESCRIPTION
Ref: https://nodejs.org/api/esm.html#esm_import_specifiers
This makes node@14 able to import zen-observable directly 