### PR TITLE
Add native Node.js ES Modules support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.DS_Store
-_*
-node_modules
-lib
+dist/
+lib/
+node_modules/

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-.DS_Store
-node_modules

--- a/esm.js
+++ b/esm.js
@@ -1,5 +1,0 @@
-import { Observable } from './src/Observable.js';
-
-export default Observable;
-export { Observable };
-export * from './src/extras.js';

--- a/extras.js
+++ b/extras.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/extras.js');

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/Observable.js').Observable;

--- a/package-lock.json
+++ b/package-lock.json
@@ -262,6 +262,12 @@
         "@babel/types": "^7.4.4"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+      "dev": true
+    },
     "@babel/helper-wrap-function": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
@@ -843,6 +849,55 @@
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@rollup/plugin-babel": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.0.3.tgz",
+      "integrity": "sha512-NlaPf4E6YFxeOCbqc+A2PTkB1BSy3rfKu6EJuQ1MGhMHpTVvMqKi6Rf0DlwtnEsTNK9LueUgsGEgp5Occ4KDVA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.7.4",
+        "@rollup/pluginutils": "^3.0.8"
+      },
+      "dependencies": {
+        "@babel/helper-module-imports": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
+          "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/types": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "acorn": {
       "version": "7.1.0",
@@ -1657,6 +1712,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
     },
     "esutils": {
@@ -3517,6 +3578,12 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -3764,6 +3831,24 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.14.0.tgz",
+      "integrity": "sha512-SUsFh2bBemQqCXOCBWRayjK3/6kNHVR8PbSKKYWIdI6e4zuGSW5B1hGVkFi40805dUrqosMLLxMuEyJMylC9YA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -5,19 +5,32 @@
   "description": "An Implementation of ES Observables",
   "homepage": "https://github.com/zenparsing/zen-observable",
   "license": "MIT",
+  "main": "./dist/cjs/index.js",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/es/index.js"
+  },
+  "module": "./dist/es/index.js",
+  "type": "commonjs",
   "devDependencies": {
     "@babel/cli": "^7.6.0",
     "@babel/core": "^7.6.0",
     "@babel/preset-env": "^7.6.0",
     "@babel/register": "^7.6.0",
+    "@rollup/plugin-babel": "^5.0.0",
     "eslint": "^6.5.0",
-    "mocha": "^6.2.0"
+    "mocha": "^6.2.0",
+    "rollup": "^2.14.0"
   },
   "dependencies": {},
   "scripts": {
-    "test": "mocha --recursive --require ./scripts/mocha-require",
+    "build": "rollup --config",
     "lint": "eslint src/*",
-    "build": "git clean -dfX ./lib && node ./scripts/build",
-    "prepublishOnly": "npm run lint && npm test && npm run build"
-  }
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run lint && npm test",
+    "test": "mocha --recursive --require ./scripts/mocha-require"
+  },
+  "files": [
+    "dist/"
+  ]
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,28 @@
+import { babel } from '@rollup/plugin-babel';
+
+function emitModulePackageFile() {
+  return {
+    name: 'emit-module-package-file',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'package.json',
+        source: '{"type":"module"}',
+      });
+    },
+  };
+}
+
+export default {
+  input: ['src/index.js', 'src/extras.js'],
+  output: [
+    { dir: 'dist/cjs/', format: 'cjs', exports: 'named' },
+    { dir: 'dist/es/', format: 'es', plugins: [emitModulePackageFile()] },
+  ],
+  plugins: [
+    babel({
+      babelHelpers: 'bundled',
+      plugins: require('./scripts/babel-plugins'),
+    }),
+  ],
+};

--- a/scripts/babel-plugins.js
+++ b/scripts/babel-plugins.js
@@ -8,7 +8,6 @@ module.exports = [
   '@babel/plugin-transform-duplicate-keys',
   '@babel/plugin-transform-for-of',
   '@babel/plugin-transform-literals',
-  '@babel/plugin-transform-modules-commonjs',
   '@babel/plugin-transform-parameters',
   '@babel/plugin-transform-shorthand-properties',
   '@babel/plugin-transform-spread',

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,7 +1,0 @@
-const { execSync } = require('child_process');
-const plugins = require('./babel-plugins');
-
-execSync('babel src --out-dir lib --plugins=' + plugins.join(','), {
-  env: process.env,
-  stdio: 'inherit',
-});

--- a/scripts/mocha-require.js
+++ b/scripts/mocha-require.js
@@ -1,3 +1,6 @@
 require('@babel/register')({
-  plugins: require('./babel-plugins'),
+  plugins: [
+    ...require('./babel-plugins'),
+    '@babel/plugin-transform-modules-commonjs',
+  ],
 });

--- a/src/extras.js
+++ b/src/extras.js
@@ -1,4 +1,4 @@
-import { Observable } from './Observable.js';
+import { Observable } from './index.js';
 
 // Emits all values from all inputs in parallel
 export function merge(...sources) {

--- a/src/index.js
+++ b/src/index.js
@@ -474,3 +474,5 @@ if (hasSymbols()) {
     configurable: true,
   });
 }
+
+export default Observable;

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,4 @@
-import { Observable } from '../src/Observable.js';
+import { Observable } from '../src/index.js';
 
 beforeEach(() => {
   global.Observable = Observable;


### PR DESCRIPTION
In this PR I add **native Node.js ES Modules support**.

Following the same recommendations as the Rollup plugins:
- https://github.com/rollup/plugins/pull/413
- https://github.com/rollup/plugins/pull/419

Fix #62.

Also fix https://github.com/apollographql/apollo-client/issues/5961.