### PR TITLE
Add ability to use Observables with async/await

### DIFF
--- a/src/Observable.js
+++ b/src/Observable.js
@@ -314,6 +314,12 @@ export class Observable {
     }));
   }
 
+  async all() {
+    let values = [];
+    await this.forEach(value => values.push(value));
+    return values;
+  }
+
   concat(...sources) {
     let C = getSpecies(this);
 

--- a/test/all.js
+++ b/test/all.js
@@ -1,0 +1,10 @@
+import assert from 'assert';
+
+describe('all', ()=> {
+  it('should receive all the observed values in order as an array', async () => {
+    let observable = Observable.of(1,2,3,4);
+    let values = await observable.all();
+
+    assert.deepEqual(values, [1,2,3,4]);
+  });
+});


### PR DESCRIPTION
A lot of modern JavaScript code uses async/await to handle asynchronous code. This is a great way to write code that is easy to read and understand. However, it is not possible to use async/await with Observables outside of the `forEach()` which requries more boilerplate than needed in order to do so.

Changes:
 * Adds `.all()` to an observable instance allowing one to `await` the values it contains
 * Adds a test for the new functionality